### PR TITLE
improved-poetry-detection

### DIFF
--- a/src/conjuring/spells/poetry.py
+++ b/src/conjuring/spells/poetry.py
@@ -1,10 +1,10 @@
 from invoke import task
 
 from conjuring.grimoire import print_error, run_command, run_with_fzf
-from conjuring.visibility import ShouldDisplayTasks, has_pyproject_toml
+from conjuring.visibility import ShouldDisplayTasks, is_poetry_project
 
 SHOULD_PREFIX = True
-should_display_tasks: ShouldDisplayTasks = has_pyproject_toml
+should_display_tasks: ShouldDisplayTasks = is_poetry_project
 
 
 @task(help={"inject": "Pipx repo to inject this project into"})

--- a/src/conjuring/visibility.py
+++ b/src/conjuring/visibility.py
@@ -21,7 +21,7 @@ def is_git_repo() -> bool:
     return Path(".git").exists()
 
 
-def has_pyproject_toml() -> bool:
+def is_poetry_project() -> bool:
     return Path("pyproject.toml").exists()
 
 

--- a/src/conjuring/visibility.py
+++ b/src/conjuring/visibility.py
@@ -1,8 +1,10 @@
+import re
 from pathlib import Path
 from typing import Callable
 
 from invoke import Task
 
+POETRY_LINE = re.compile(r"\[tool\..*poetry\]")
 ShouldDisplayTasks = Callable[[], bool]
 
 always_visible: ShouldDisplayTasks = lambda: True
@@ -22,7 +24,12 @@ def is_git_repo() -> bool:
 
 
 def is_poetry_project() -> bool:
-    return Path("pyproject.toml").exists()
+    fpath = Path("pyproject.toml")
+    return fpath.exists() and _has_poetry_line(fpath)
+
+
+def _has_poetry_line(fpath: Path) -> bool:
+    return any(re.search(POETRY_LINE, line) for line in fpath.open())
 
 
 def display_task(task: Task, module_flag: bool) -> bool:

--- a/tests/test_conjuring.py
+++ b/tests/test_conjuring.py
@@ -4,6 +4,7 @@ import pytest
 from invoke import Collection
 
 from conjuring.grimoire import collection_from_python_files, magically_add_tasks
+from conjuring.visibility import ShouldDisplayTasks, is_poetry_project
 
 
 @pytest.fixture

--- a/tests/test_conjuring.py
+++ b/tests/test_conjuring.py
@@ -74,6 +74,12 @@ def test_module_with_magic_task(my_collection):
     assert_tasks(my_collection, ["depends-on-the-module-config", "this-task-is-always-visible"])
 
 
+def test_detects_this_project_as_poetry_project(my_collection):
+    # NOTE: assumes this project has valid pyproject.toml,
+    # should add tests for non-poetry projects with pyproject.toml still present
+    assert is_poetry_project()
+
+
 @pytest.mark.xfail(reason="Empty collection.tasks is causing this test to fail")
 def test_add_task_with_the_same_name(my_collection):
     from tests.fixtures import not_prefixed, same


### PR DESCRIPTION
Improved poetry project detection

Some projects use `pyproject.toml` to unify configuration etc, but do not use Poetry to manage dependencies. 
This should improve Poetry project detection by checking contents of file, if there's this `[tool.poetry]` line (not sure if it varies between most recent versions, hence regex)

* replace has_pyproject_toml with is_poetry_project
* check if pyproject.toml contains poetry line
